### PR TITLE
Don't display negative page numbers.

### DIFF
--- a/qmlist/templates/js/browse.js
+++ b/qmlist/templates/js/browse.js
@@ -188,7 +188,7 @@ function itemPagination(data) {
     var paginationWidth = 6;
     var startPage = Math.max(1, currentPage - Math.floor(paginationWidth / 2));
     var endPage = Math.min(data["page"]["last"], startPage + paginationWidth);
-    startPage -= paginationWidth - (endPage - startPage);
+    startPage = Math.max(1, endPage - paginationWidth);
     for (var pageno = startPage; pageno < endPage + 1; pageno++) {
         var paginationEntry = $("<li></li>")
             .addClass("page-item")


### PR DESCRIPTION
When the end page is less tha the page window, the start page should
still bottom out at 1.