### PR TITLE
Clean up pagination.

### DIFF
--- a/qmlist/templates/js/browse.js
+++ b/qmlist/templates/js/browse.js
@@ -161,51 +161,26 @@ function layoutItems(pageno) {
 
 function itemPagination(data) {
     if (data["page"]["next"]) {
-        $("#browse-items-next").parent().removeClass("disabled");
+        $("#browse-items-next").parents(".page-item").removeClass("disabled");
         $("#browse-items-next").attr("data-page", data["page"]["next"]);
-        $("#browse-items-last").parent().removeClass("disabled");
+        $("#browse-items-last").parents(".page-item").removeClass("disabled");
         $("#browse-items-last").attr("data-page", data["page"]["last"]);
     } else {
-        $("#browse-items-next").parent().addClass("disabled");
+        $("#browse-items-next").parents(".page-item").addClass("disabled");
         $("#browse-items-next").removeAttr("data-page");
-        $("#browse-items-last").parent().addClass("disabled");
+        $("#browse-items-last").parents(".page-item").addClass("disabled");
         $("#browse-items-last").removeAttr("data-page");
     }
     if (data["page"]["prev"]) {
-        $("#browse-items-prev").parent().removeClass("disabled");
+        $("#browse-items-prev").parents(".page-item").removeClass("disabled");
         $("#browse-items-prev").attr("data-page", data["page"]["prev"]);
-        $("#browse-items-first").parent().removeClass("disabled");
+        $("#browse-items-first").parents(".page-item").removeClass("disabled");
         $("#browse-items-first").attr("data-page", 1);
     } else {
-        $("#browse-items-prev").parent().addClass("disabled");
+        $("#browse-items-prev").parents(".page-item").addClass("disabled");
         $("#browse-items-prev").removeAttr("data-page");
-        $("#browse-items-first").parent().addClass("disabled");
+        $("#browse-items-first").parents(".page-item").addClass("disabled");
         $("#browse-items-first").removeAttr("data-page");
-    }
-
-    $("#browse-items-pagination-pages").find(".page-link[id!=browse-items-prev][id!=browse-items-next][id!=browse-items-first][id!=browse-items-last]").parent().empty();
-    var currentPage = data["page"]["current"];
-    var paginationWidth = 6;
-    var startPage = Math.max(1, currentPage - Math.floor(paginationWidth / 2));
-    var endPage = Math.min(data["page"]["last"], startPage + paginationWidth);
-    startPage = Math.max(1, endPage - paginationWidth);
-    for (var pageno = startPage; pageno < endPage + 1; pageno++) {
-        var paginationEntry = $("<li></li>")
-            .addClass("page-item")
-            .append($("<a></a>")
-                .addClass("page-link")
-                .attr("href", "#")
-                .attr("data-page", pageno)
-                .text(pageno)
-                .click(function() {
-                    layoutItems($(this).attr("data-page"));
-                }));
-
-        if (pageno == currentPage) {
-            paginationEntry.addClass("active");
-        }
-
-        paginationEntry.insertBefore($("#browse-items-next").parent());
     }
 
     $("#current-page-display").text(data["page"]["current"]);

--- a/qmlist/templates/tabs/browse-tab.html
+++ b/qmlist/templates/tabs/browse-tab.html
@@ -30,16 +30,17 @@
         <div class="col">
             <nav aria-label="Browse store items" id="browse-items-pagination" style="display: inline">
                 <ul class="pagination justify-content-center" id="browse-items-pagination-pages">
-                    <li class="page-item"><a class="page-link" href="#" id="browse-items-first">First Page</a></li>
-                    <li class="page-item"><a class="page-link" href="#" id="browse-items-prev">Previous</a></li>
-                    <li class="page-item"><a class="page-link" href="#" id="browse-items-next">Next</a></li>
-                    <li class="page-item"><a class="page-link" href="#" id="browse-items-last">Last Page</a></li>
+                    <li class="page-item"><a class="page-link" href="#" id="browse-items-first"><i class="fa fa-angle-double-left fa-lg"></i></a></li>
+                    <li class="page-item"><a class="page-link" href="#" id="browse-items-prev"><i class="fa fa-caret-left fa-lg">&nbsp;</i></a></li>
+                    <li class="page-item" style="font-style: italic; margin: 5px 10px 0px;">
+                        <span id="current-page-display"></span> of <span id="last-page-display"></span>
+                    </li>
+                    <li class="page-item"><a class="page-link" href="#" id="browse-items-next"><i class="fa fa-caret-right fa-lg"></i></a></li>
+                    <li class="page-item"><a class="page-link" href="#" id="browse-items-last"><i class="fa fa-angle-double-right fa-lg"></i></a></li>
                 </ul>
             </nav>
         </div>
-        <div class="col-2" style="font-style: italic; margin-top: 5px">
-            page <span id="current-page-display"></span> of <span id="last-page-display"></span>
-        </div>
+        <div class="col-2">&nbsp;</div>
     </div>
     <div class="row">
         <div class="col-12">


### PR DESCRIPTION
Use icons to label the buttons. Place the page count (total and current)
in between the pagination buttons, and remove the specific page buttons.