### PR TITLE
In the search tab, tag each result with its store.

### DIFF
--- a/qmlist/templates/js/browse.js
+++ b/qmlist/templates/js/browse.js
@@ -98,7 +98,7 @@ function layoutItems(pageno) {
                     .attr("data-name", item["name"])
                     .append($("<div></div>")
                         .addClass("text-truncate")
-                        .attr("style", "max-width: 93%")
+                        .attr("style", "max-width: 85%")
                         .text(item["name"]));
 
                 if ($("#shopping-list").attr("data-editable") === "true") {

--- a/qmlist/templates/js/search.js
+++ b/qmlist/templates/js/search.js
@@ -27,11 +27,21 @@ function search(shoppingListName, searchTerm, pageno) {
                     .addClass("align-items-center")
                     .attr("data-name", result["name"])
                     .append($("<div></div>")
-                        .addClass("text-truncate")
-                        .attr("style", "max-width: 93%")
-                        .attr("data-toggle", "tooltip")
-                        .attr("title", result["name"])
-                        .text(result["name"]));
+                        .css({"max-width": "85%"})
+                        .append($("<div></div>")
+                            .css({"float": "left"})
+                            .addClass("text-truncate")
+                            .attr("data-toggle", "tooltip")
+                            .attr("title", result["name"])
+                            .text(result["name"]))
+                        .append($("<div></div>")
+                            .css({"width": "5px", "float": "left"})
+                            .html("&nbsp;"))
+                        .append($("<div></div>")
+                            .css({"float": "left"})
+                            .addClass("badge")
+                            .addClass(result["store"] === "BJs" ? "badge-danger" : "badge-primary")
+                            .text(result["store"])));
 
                 if ($("#shopping-list").attr("data-editable") === "true") {
                     var quantity = quantityButtons(

--- a/qmlist/views.py
+++ b/qmlist/views.py
@@ -52,7 +52,7 @@ def search():
             .limit(ITEM_PAGE_SIZE)
             .all())
 
-    page_result_dicts = [{"name": product.name, "quantity": shopping_list.get_item(product.name).quantity} for product in page_results]
+    page_result_dicts = [{"name": product.name, "quantity": shopping_list.get_item(product.name).quantity, "store": product.store} for product in page_results]
     return jsonify({"search-results": page_result_dicts, "search-term": search_term, "total-results": all_results.count()})
 
 def _get_category_path(category):


### PR DESCRIPTION
This allows the user to consider the store without needing to use the
browse store tabs.

Resolves #10 