### PR TITLE
Archiving lists on admin console, and management tab.

### DIFF
--- a/qmlist/model.py
+++ b/qmlist/model.py
@@ -38,19 +38,28 @@ class ShoppingList(db.Model):
     name = db.Column(db.String(255), unique=True)
     departure = db.Column(db.DateTime)
     rtmid = db.Column(db.Integer)
+    isarchived = db.Column(db.Boolean, default=False)
+
+    @staticmethod
+    def archived():
+        return ShoppingList.query.filter_by(isarchived=True)
+
+    @staticmethod
+    def active():
+        return ShoppingList.query.filter_by(isarchived=False)
 
     @staticmethod
     def next():
         lists_after_now = ShoppingList.future()
         next_list = min(lists_after_now, key=operator.attrgetter("departure")) if lists_after_now else None
         if not next_list:
-            all_lists = ShoppingList.query.all()
+            all_lists = ShoppingList.active().all()
             next_list = max(all_lists, key=operator.attrgetter("departure")) if all_lists else None
         return next_list
 
     @staticmethod
     def future():
-        return ShoppingList.query.filter(ShoppingList.departure >= datetime.datetime.now()).all()
+        return ShoppingList.active().filter(ShoppingList.departure >= datetime.datetime.now()).all()
 
 class Categories(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/qmlist/templates/tabs/admin-console-tab.html
+++ b/qmlist/templates/tabs/admin-console-tab.html
@@ -2,9 +2,15 @@
     <li class="nav-item">
         <a class="nav-link active" id="admin-console-lists-tab" data-toggle="tab" href="#admin-console-lists" role="tab" aria-controls="search" aria-selected="true">Lists</a>
     </li>
+    <li class="nav-item">
+        <a class="nav-link" id="admin-console-archive-tab" data-toggle="tab" href="#admin-console-archive" role="tab" aria-controls="search" aria-selected="true">Archive</a>
+    </li>
 </ul>
 <div class="tab-content mt-2" id="admin-console-nav-tabs-content">
     <div class="tab-pane show active" id="admin-console-lists" role="tabpanel" aria-labelledby="admin-console-lists-tab">
         {% include "tabs/admin-console-tabs/lists-tab.html" %}
+    </div>
+    <div class="tab-pane" id="admin-console-archive" role="tabpanel" aria-labelledby="admin-console-archive-tab">
+        {% include "tabs/admin-console-tabs/archive-tab.html" %}
     </div>
 </div>

--- a/qmlist/templates/tabs/admin-console-tabs/archive-tab.html
+++ b/qmlist/templates/tabs/admin-console-tabs/archive-tab.html
@@ -1,0 +1,1 @@
+<ul class="list-group" id="admin-console-archived-lists"></ul>


### PR DESCRIPTION
Users may want access to their lists year to year, but allowing the main
list to grow indefinitely could become unwiedly and unmanageable. This
allows the admin to archive a list, which simply flags it in our system,
and otherwise leaves the list in tact. It won't show up in the loading
dropdown, nor the main list management tab.

To facillitate this, the archived column was added to the shopping_list
table. Two non-table classes were also added to the model to simplify
filtering a query based on archived.

To manage these archived lists, a new tab was added to the admin console.
It simply dislays the lists (name and departure), and allows the admin to
unarchive or delete them. They cannot be otherwise edited.

To ensure consistency with the list management tab, the code was
refactored such that the archived tab is populated using the same code,
but with the archived parameter set to true.

Resolves #42 and #43 