### PR TITLE
Handle dates as timestamps, and format in JS.

### DIFF
--- a/qmlist/model.py
+++ b/qmlist/model.py
@@ -36,7 +36,7 @@ class Department(db.Model):
 class ShoppingList(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(255), unique=True)
-    departure = db.Column(db.DateTime)
+    departure = db.Column(db.BigInteger)
     rtmid = db.Column(db.Integer)
     isarchived = db.Column(db.Boolean, default=False)
 
@@ -59,7 +59,7 @@ class ShoppingList(db.Model):
 
     @staticmethod
     def future():
-        return ShoppingList.active().filter(ShoppingList.departure >= datetime.datetime.now()).all()
+        return ShoppingList.active().filter(ShoppingList.departure >= datetime.datetime.now().timestamp()).all()
 
 class Categories(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/qmlist/shoppinglist/shoppinglist.py
+++ b/qmlist/shoppinglist/shoppinglist.py
@@ -70,7 +70,7 @@ class PersistentShoppingList(object):
             return self.items[name].quantity
 
     def is_editable(self):
-        return self.departure >= datetime.datetime.now()
+        return self.departure >= datetime.datetime.now().timestamp()
 
     def delete(self):
         rtmlib.delete_list(self._client, self._id)


### PR DESCRIPTION
Instead of doing datetime management in the backend, report all times as
Unix timestamps, and handle formatting on the JS side. This eases parsing
and displaying the input datetimes, as they're all done in the same place
in the JS.