### PR TITLE
Sort lists by departure time.

### DIFF
--- a/qmlist/templates/js/admin-console/list-management.js
+++ b/qmlist/templates/js/admin-console/list-management.js
@@ -46,6 +46,7 @@ function adminConsoleDisplayLists(rootElementId, lists, archiveView) {
     archiveView = archiveView || false;
 
     $(`#${rootElementId}`).empty();
+    lists.sort((first, second) => first["departure"] - second["departure"]);
     lists.forEach(list_info => {
         var departureStr = moment.unix(list_info["departure"]).format(LIST_DATEPICKER_FORMAT);
 

--- a/qmlist/templates/js/shopping-list-picker.js
+++ b/qmlist/templates/js/shopping-list-picker.js
@@ -26,6 +26,7 @@ $("#load-list-dropdown").on("show.bs.dropdown", function() {
     $.get("{{ url_for('get_list_info') }}")
         .done(function(data) {
             $("#shopping-list-picker").empty();
+            data["lists"].sort((first, second) => first["departure"] - second["departure"]);
             data["lists"].forEach(list_info => {
                 $("#shopping-list-picker")
                     .append($("<a></a>")


### PR DESCRIPTION
Hard-coded to be in ascending order (closest departure to latest).
I'll consider allowing user-controlled sorting options later, but I don't
currently see that as useful.

Resolves #64 