### PR TITLE
Add shopping list export.

### DIFF
--- a/qmlist/shoppinglist/rtm/rtmlib.py
+++ b/qmlist/shoppinglist/rtm/rtmlib.py
@@ -140,6 +140,10 @@ def delete_list(rtm_client, list_id):
     timeline = rtm_client.rtm.timelines.create().timeline.value
     rtm_client.rtm.lists.delete(timeline=timeline, list_id=str(list_id))
 
+def archive_list(rtm_client, list_id):
+    timeline = rtm_client.rtm.timelines.create().timeline.value
+    rtm_client.rtm.lists.archive    (timeline=timeline, list_id=str(list_id))
+
 def _item_as_dict(taskseries, list_id):
     return {
         "id": taskseries.id,

--- a/qmlist/shoppinglist/shoppinglist.py
+++ b/qmlist/shoppinglist/shoppinglist.py
@@ -7,7 +7,8 @@ class PersistentShoppingList(object):
     @staticmethod
     def load(name, id, departure, tags=[], client=None):
         client = client or rtmlib.connect()
-        
+
+        name = f"{name} (old)"
         items = [Item.load(client, rtm_item) for rtm_item in rtmlib.load_list_items(client, id) if not tags or rtm_item["tags"] == tags]
         return PersistentShoppingList(id, name, items, departure, tags, client)
 
@@ -15,6 +16,7 @@ class PersistentShoppingList(object):
     def get(name, departure, client=None):
         client = client or rtmlib.connect()
 
+        name = f"{name} (old)"
         list_ids = rtmlib.get_list_ids(client, name)
         if list_ids:
             return PersistentShoppingList.load(name, list_ids[0], departure, client=client)
@@ -25,6 +27,7 @@ class PersistentShoppingList(object):
     def create(name, departure, tags=[], client=None):
         client = client or rtmlib.connect()
 
+        name = f"{name} (old)"
         new_list = rtmlib.create_list(client, name)
 
         return PersistentShoppingList(new_list.id, name, [], departure, tags, client)
@@ -46,8 +49,9 @@ class PersistentShoppingList(object):
 
     @name.setter
     def name(self, value):
-        rtmlib.rename_list(self._client, self._id, value)
-        self._name = value
+        name = f"{value} (old)"
+        rtmlib.rename_list(self._client, self._id, name)
+        self._name = name
 
     def get_item(self, name):
         return self.items.get(name) if name in self.items else NewItem(self._client, self._id, name, self.tags)

--- a/qmlist/templates/js/admin-console/list-management.js
+++ b/qmlist/templates/js/admin-console/list-management.js
@@ -15,18 +15,25 @@ function adminConsoleListControl(archiveView) {
                     });
             }));
     } else {
-        controlArea.append(faButton("fa", "fa-folder", {"size": "lg", "color": "blue", "margin-left": "15px", "float": "left"})
-            .click(function() {
-                var root = $(this).parents("li");
-                var listName = root.attr("data-shopping-list");
-                $.post("{{ url_for('archive_list') }}", {shopping_list: listName})
-                    .done(function(data) {
-                        root.remove();
-                        if ($("#list-tab").attr("data-list-name") === listName) {
-                            loadShoppingListTab(data["load"]);
-                        }
-                    });
-            }));
+        controlArea
+            .append(faButton("fa", "fa-cart-arrow-down", {"size": "lg", "color": "green", "margin-left": "15px", "float": "left"})
+                .click(function() {
+                    var root = $(this).parents("li");
+                    var listName = root.attr("data-shopping-list");
+                    $.post("{{ url_for('export_list') }}", {shopping_list: listName});
+                }))
+            .append(faButton("fa", "fa-folder", {"size": "lg", "color": "blue", "margin-left": "15px", "float": "left"})
+                .click(function() {
+                    var root = $(this).parents("li");
+                    var listName = root.attr("data-shopping-list");
+                    $.post("{{ url_for('archive_list') }}", {shopping_list: listName})
+                        .done(function(data) {
+                            root.remove();
+                            if ($("#list-tab").attr("data-list-name") === listName) {
+                                loadShoppingListTab(data["load"]);
+                            }
+                        });
+                }));
     }
 
     controlArea.append(faButton("fa", "fa-trash", {"size": "lg", "color": "red", "margin-left": " 5px", "float": "left"})


### PR DESCRIPTION
Allows the list to be written anew to RtM on-demand. Any pre-existing
RtM list associated with the database entry will be archived. This is
because when a list is deleted through the API, all its items are shifted
into the user's Inbox, so they still show up in tags and smart lists. And
while deleting every item is an option, due to the lack of a bulk delete
endpoint and the slowness of their API, it would take far too long.

Resolves #90 