### PR TITLE
Change quantity buttons to span elements.

### DIFF
--- a/qmlist/static/css/qmlist.css
+++ b/qmlist/static/css/qmlist.css
@@ -35,12 +35,12 @@
   border-color: transparent LightGray;
 }
 
-a[disabled] {
+[disabled] {
     pointer-events: none;
     cursor: default;
 }
 
-a.decr-btn[disabled] i {
+.decr-btn[disabled] i {
     color: #e87c86 !important;
 }
 

--- a/qmlist/static/js/utils.js
+++ b/qmlist/static/js/utils.js
@@ -23,7 +23,7 @@ function faButton(iconStyle, iconName, kwargs) {
         icon.css("float", kwargs["float"]);
     }
 
-    return $("<a></a>")
-        .attr("href", "#")
+   return $("<span></span>")
+        .css("cursor", "pointer")
         .append(icon);
 }


### PR DESCRIPTION
This prevents them from triggering the page to jump to the top when
clicked.

Resolve #93 