### PR TITLE
Set editability on tab load.

### DIFF
--- a/qmlist/templates/js/browse.js
+++ b/qmlist/templates/js/browse.js
@@ -89,6 +89,7 @@ $("#nav-tabs").on("show.bs.tab", function(event) {
             $("#browse-items-prev").parent().addClass("disabled");
             $("#browse-items-first").parent().addClass("disabled");
 
+            setShoppingListEditability(shoppingListName);
             layoutCategories(1);
             browseItems(1);
             resetItemPagination();

--- a/qmlist/templates/js/search.js
+++ b/qmlist/templates/js/search.js
@@ -25,6 +25,7 @@ $("#search-box").keypress(function(event){
 
 $("#nav-tabs").on("show.bs.tab", function(event) {
     if ($(event.target).attr("id") === "search-tab") {
+        setShoppingListEditability($("#list-tab").attr("data-list-name"));
         $("#search-box").val("");
         $("#search-items").empty();
         resetItemPagination();


### PR DESCRIPTION
This ensures the editability value is up to date when a tab is loaded
which could modify its contents.

Resolve #94 