### PR TITLE
Fix loading list tab with no lists.

### DIFF
--- a/qmlist/templates/index.html
+++ b/qmlist/templates/index.html
@@ -56,10 +56,10 @@
 {% include "js/shopping-list-picker.js" %}
 {% include "js/admin-console/list-management.js" %}
 
-loadShoppingListTab({% if default_list_name %}"{{ default_list_name }}"{% endif %});
-
 {% if is_admin %}
 $("#admin-console-tab").tab("show");
 {% endif %}
+
+loadShoppingListTab({% if default_list_name %}"{{ default_list_name }}"{% endif %});
 
 {% endblock %}

--- a/qmlist/templates/js/shopping-list-picker.js
+++ b/qmlist/templates/js/shopping-list-picker.js
@@ -7,8 +7,21 @@ function setListTabName(shoppingListName) {
     }
 }
 
+function setListTabEnabled(shoppingListName) {
+    if (shoppingListName === undefined || shoppingListName === null) {
+        $("#list-tab")
+            .addClass("disabled")
+            .css("cursor", "default");
+    } else {
+        $("#list-tab")
+            .removeClass("disabled")
+            .css("cursor", "pointer");
+    }
+}
+
 function loadShoppingListTab(shoppingListName) {
     setListTabName(shoppingListName);
+    setListTabEnabled(shoppingListName);
 
     if ($("#search-tab").hasClass("active")) {
         setShoppingListEditability(shoppingListName);

--- a/qmlist/templates/js/shopping-list.js
+++ b/qmlist/templates/js/shopping-list.js
@@ -3,33 +3,34 @@ function _shoppingListEditability(isEditable) {
 }
 
 function setShoppingListEditability(shoppingListName) {
+    if (shoppingListName === undefined || shoppingListName === null) {
+        _shoppingListEditability(false);
+    } else {
+        $.get("{{ url_for('load_shopping_list') }}", {"shopping-list": shoppingListName})
+            .done(function(data) {
+                _shoppingListEditability(data["editable"]);
+            })
+            .fail(function(jqXHR, textStatus) {
+                alert(textStatus);
+            });
+        }
+}
+
+function loadShoppingList(shoppingListName) {
+    setListTabEnabled(shoppingListName);
     $.get("{{ url_for('load_shopping_list') }}", {"shopping-list": shoppingListName})
         .done(function(data) {
             _shoppingListEditability(data["editable"]);
+
+            displayItems(data, shoppingListName, true);
         })
         .fail(function(jqXHR, textStatus) {
             alert(textStatus);
         });
 }
 
-function loadShoppingList(shoppingListName) {
-    if (shoppingListName === undefined || shoppingListName === null) {
-        $("#list-tab").addClass("disabled");
-    } else {
-        $("#list-tab").removeClass("disabled");
-
-        $.get("{{ url_for('load_shopping_list') }}", {"shopping-list": shoppingListName})
-            .done(function(data) {
-                _shoppingListEditability(data["editable"]);
-
-                displayItems(data, shoppingListName, true);
-            })
-            .fail(function(jqXHR, textStatus) {
-                alert(textStatus);
-            });
-    }
-}
-
 $("#list-tab").click(function() {
-     loadShoppingList($("#list-tab").attr("data-list-name"));
+    if (!$("#list-tab").hasClass("disabled")) {
+        loadShoppingList($("#list-tab").attr("data-list-name"));
+    }
 });


### PR DESCRIPTION
The list editability should default to false if no list has been loaded.
Also, when no list has been loaded, the tab should not be clickable.