### PR TITLE
Adding categories admin console tab.

### DIFF
--- a/qmlist/model.py
+++ b/qmlist/model.py
@@ -69,6 +69,15 @@ class Categories(db.Model):
     parentid = db.Column(db.Integer, db.ForeignKey("categories.id"))
     children = db.relationship('Categories', backref=db.backref('parent', remote_side=id), lazy="dynamic")
     products = db.relationship('Product', backref='category', lazy=True)
+    isenabled = db.Column(db.Boolean, default=True)
+
+    @staticmethod
+    def enabled():
+        return Categories.query.filter_by(isenabled=True)
+
+    @staticmethod
+    def disabled():
+        return Categories.query.filter_by(isenabled=False)
 
 class Product(db.Model):
     sku = db.Column(db.String(32), primary_key=True)

--- a/qmlist/static/css/qmlist.css
+++ b/qmlist/static/css/qmlist.css
@@ -44,6 +44,28 @@
     color: #e87c86 !important;
 }
 
+.btn-outline-success.collapsed {
+    border-color: #ade0b5;
+    color: #ade0b5;
+    background-color: transparent;
+}
+
+.btn-outline-success.collapsed:hover {
+    background-color: #ade0b5;
+    color: white;
+}
+
+.btn-outline-danger.collapsed {
+    border-color: #f5b5bb;
+    color: #f5b5bb;
+    background-color: transparent;
+}
+
+.btn-outline-danger.collapsed:hover {
+    background-color: #f5b5bb;
+    color: white;
+}
+
 /* For the datetime picker */
 .dtp .btn {
     font-size: 14px;

--- a/qmlist/templates/index.html
+++ b/qmlist/templates/index.html
@@ -55,6 +55,7 @@
 {% include "js/shopping-list.js" %}
 {% include "js/shopping-list-picker.js" %}
 {% include "js/admin-console/list-management.js" %}
+{% include "js/admin-console/category-management.js" %}
 
 {% if is_admin %}
 $("#admin-console-tab").tab("show");

--- a/qmlist/templates/js/admin-console/category-management.js
+++ b/qmlist/templates/js/admin-console/category-management.js
@@ -1,0 +1,129 @@
+function _createSubcategoryButton() {
+    return faButton("fa", "fa-chevron-right", {color: "black", "margin-left": "10px", "margin-right": "10px"})
+        .click(function() {
+            var categoryRow = $(this).parents(`[data-name]`);
+            var store = categoryRow.parents("[data-store]").attr("data-store");
+            var category = categoryRow.attr("data-name");
+            $.get("{{ url_for('load_subcategories') }}", {store: store, category: category})
+                .done((data) => {
+                    var column = categoryRow.parent();
+
+                    column.find(`[data-name='${category}'] button`).removeClass("collapsed");
+                    column.find(`:not([data-name='${category}']) button`).addClass("collapsed");
+
+                    column.nextAll().remove();
+                    column.parent()
+                        .append(_displayStoreCategories(data["subcategories"], category));
+                });
+        })
+}
+
+function _createCategoryButton(name, enabled) {
+    var categoryButton = $("<button></button>")
+        .attr("type", "button")
+        .addClass("btn")
+        .addClass("btn-sm")
+        .addClass(enabled ? "btn-outline-success" : "btn-outline-danger")
+        .css("float", "left")
+        .text(name)
+        .click(function(event) {
+            var categoryRow = $(this).parents(`[data-name]`);
+            var buttonEnabled = categoryRow.attr("data-enabled");
+            var store = categoryRow.parents("[data-store]").attr("data-store");
+            var category = categoryRow.attr("data-name");
+            var parent = categoryRow.attr("data-parent");
+            if (buttonEnabled === "true") {
+                $.post("{{ url_for('category_disable') }}", {store: store, category: category})
+                    .done(() => {
+                        $(this)
+                            .removeClass("btn-outline-success")
+                            .addClass("btn-outline-danger");
+
+                        categoryRow
+                            .attr("data-enabled", "false");
+
+                        if (!$(this).hasClass("collapsed")) {
+                            categoryRow.parent().nextAll().find("[data-enabled]")
+                                .attr("data-enabled", "false");
+
+                            categoryRow.parent().nextAll().find("button")
+                                .removeClass("btn-outline-success")
+                                .addClass("btn-outline-danger");
+                        }
+                    });
+            } else {
+                if (parent === undefined || categoryRow.parent().prev().find(`[data-name='${parent}']`).attr("data-enabled") === "true") {
+                    var propagate = event.ctrlKey;
+                    $.post("{{ url_for('category_enable') }}", {store: store, category: category, propagate: propagate})
+                        .done(() => {
+                            $(this)
+                                .removeClass("btn-outline-danger")
+                                .addClass("btn-outline-success");
+                            
+                            $(this).parents(`[data-name]`)
+                                .attr("data-enabled", "true");
+
+                            if (propagate && !$(this).hasClass("collapsed")) {
+                                categoryRow.parent().nextAll().find("[data-enabled]")
+                                    .attr("data-enabled", "true");
+
+                                categoryRow.parent().nextAll().find("button")
+                                    .removeClass("btn-outline-danger")
+                                    .addClass("btn-outline-success");
+                            }
+                        });
+                }
+            }
+        });
+
+    
+    return categoryButton;
+}
+
+function _displayStoreCategories(categories, parent) {
+    var column = $("<div></div>")
+        .css("float", "left");
+
+    categories
+        .sort((cat1, cat2) => cat1["name"].localeCompare(cat2["name"]))
+        .forEach(category => {
+            var categorySection = $("<div></div>")
+                .css("margin-top", "5px")
+                .css("margin-bottom", "5px")
+                .attr("data-name", category["name"])
+                .attr("data-enabled", category["enabled"])
+                .append(_createCategoryButton(category["name"], category["enabled"]));
+
+            if (parent !== undefined && parent !== null) {
+                categorySection.attr("data-parent", parent);
+            }
+
+            if (category["hasChildren"]) {
+                categorySection.append(_createSubcategoryButton());
+            }
+
+            column
+                .append(categorySection)
+                .append($("<div></div>")
+                    .css("clear", "both"));
+    });
+
+    return column;
+}
+
+function loadCategories() {
+    $.get("{{ url_for('load_subcategories') }}", {"store": "Restaurant Depot"})
+        .done(function(data) {
+            $("#admin-console-rd-categories")
+                .append(_displayStoreCategories(data["subcategories"]));
+        });
+    $.get("{{ url_for('load_subcategories') }}", {"store": "BJs"})
+        .done(function(data) {
+            $("#admin-console-bjs-categories")
+                .append(_displayStoreCategories(data["subcategories"]));
+        });
+}
+
+$("#admin-console-categories-tab").on("show.bs.tab", function() {
+    loadCategories();
+});

--- a/qmlist/templates/tabs/admin-console-tab.html
+++ b/qmlist/templates/tabs/admin-console-tab.html
@@ -1,9 +1,12 @@
 <ul class="nav nav-tabs" id="admin-console-nav-tabs" role="tablist">
     <li class="nav-item">
-        <a class="nav-link active" id="admin-console-lists-tab" data-toggle="tab" href="#admin-console-lists" role="tab" aria-controls="search" aria-selected="true">Lists</a>
+        <a class="nav-link active" id="admin-console-lists-tab" data-toggle="tab" href="#admin-console-lists" role="tab" aria-controls="admin-console-lists" aria-selected="true">Lists</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" id="admin-console-archive-tab" data-toggle="tab" href="#admin-console-archive" role="tab" aria-controls="search" aria-selected="true">Archive</a>
+        <a class="nav-link" id="admin-console-archive-tab" data-toggle="tab" href="#admin-console-archive" role="tab" aria-controls="admin-console-archive" aria-selected="true">Archive</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="admin-console-categories-tab" data-toggle="tab" href="#admin-console-categories" role="tab" aria-controls="admin-console-categories" aria-selected="true">Categories</a>
     </li>
 </ul>
 <div class="tab-content mt-2" id="admin-console-nav-tabs-content">
@@ -12,5 +15,8 @@
     </div>
     <div class="tab-pane" id="admin-console-archive" role="tabpanel" aria-labelledby="admin-console-archive-tab">
         {% include "tabs/admin-console-tabs/archive-tab.html" %}
+    </div>
+    <div class="tab-pane" id="admin-console-categories" role="tabpanel" aria-labelledby="admin-console-categories-tab">
+        {% include "tabs/admin-console-tabs/categories-tab.html" %}
     </div>
 </div>

--- a/qmlist/templates/tabs/admin-console-tabs/categories-tab.html
+++ b/qmlist/templates/tabs/admin-console-tabs/categories-tab.html
@@ -1,0 +1,5 @@
+<h4>Restaurant Depot</h4>
+<div id="admin-console-rd-categories" data-store="Restaurant Depot"></div>
+<hr style="margin-top: 10px; clear: both" />
+<h4>BJs</h4>
+<div id="admin-console-bjs-categories" data-store="BJs"></div>


### PR DESCRIPTION
On this tab, the admin can modify which categories are enabled and
disabled. Disabled categories and their products won't show up in browse
or search results.

To expand a category's chidlren (if it has any), click on the right-arrow.
To disable a category or subcategory, click the category itself, which is
a button. That category and all its children will turn red - if a parent
is disabled, it wouldn't make sense for its children to be enabled. If
you click on a disabled category, that category, and only that category,
will be enabled. If you wish to also re-enable all children, the user can
Ctrl-click on a disabled category.

Resolves #30 